### PR TITLE
Fix uncaught AttributeError when parsing JATS references with xlink: attributes

### DIFF
--- a/adsrefpipe/refparsers/JATSxml.py
+++ b/adsrefpipe/refparsers/JATSxml.py
@@ -308,12 +308,18 @@ class JATStoREFs(XMLtoREFs):
         (re.compile(r'<disp-formula>.*?</disp-formula>'), ''),
         # (re.compile(r'<\w*\:?math>.*?</\w*\:?math>'), ''),
         (re.compile(r'ext-link.*href='), 'ext-link href='),
-        (re.compile(r'\s+xlink:href='), ' href=')
+        (re.compile(r'\s+xlink:href='), ' href='),
+        # strip any other xlink:-prefixed attribute (eg xlink:type) since the xlink namespace is
+        # never declared once a reference is extracted and parsed as a standalone XML snippet,
+        # which makes expat raise an "unbound prefix" error
+        (re.compile(r'\s+xlink:\w+="[^"]*"'), '')
     ]
     # to clean up references by replacing certain patterns
     reference_cleanup = [
         (re.compile(r'</?uri.*?>'), ''),
         (re.compile(r'\s+xlink:href='), ' href='),
+        # strip any other xlink:-prefixed attribute (eg xlink:type), see block_cleanup above
+        (re.compile(r'\s+xlink:\w+="[^"]*"'), ''),
         (re.compile(r'\(<comment>.*?</comment>\)'), ''),
         (re.compile(r'<inline-formula[\w\s="\']*>.*?</inline-formula>', re.DOTALL), ''),
         (re.compile(r'<label>.*?</label>'), ''),

--- a/adsrefpipe/refparsers/xmlFile.py
+++ b/adsrefpipe/refparsers/xmlFile.py
@@ -121,7 +121,12 @@ class XmlString(XmlList):
                             buffer = buffer.replace(remove_text,'')
                     continue
                 except AttributeError:
-                    return
+                    # unable to locate the offending tag (eg an expat error whose reported
+                    # position does not correspond to a tag boundary, such as "unbound prefix");
+                    # give up on the extraction and fall through to the text fallback below,
+                    # rather than returning here, which would leave this object without
+                    # ever calling XmlList.__init__, and hence without a childNodes attribute
+                    break
 
         # no success, so turn xml into text, remove < and > if any, and then put one tag around it
         # to be able to extract it as text from this structure

--- a/adsrefpipe/tests/unittests/test_ref_parsers_xml.py
+++ b/adsrefpipe/tests/unittests/test_ref_parsers_xml.py
@@ -120,7 +120,9 @@ class TestXmlString(unittest.TestCase):
 
     @patch("xml.dom.minidom.parseString")
     def test_init_exception(self, mock_parse_string):
-        """ test initialization when there is an exception """
+        """ test initialization when the tag-removal recovery cannot locate the offending tag:
+        it should fall back to the text-extraction path (rather than returning with the object
+        left without a childNodes attribute) """
 
         # simulate ExpatError only on the first call with a properly formatted error message
         parse_attempts = []
@@ -134,8 +136,11 @@ class TestXmlString(unittest.TestCase):
         # create XmlString instance with invalid XML to trigger exception
         xml_string = XmlString(buffer="InvalidTag<no-match-here>ValidContent")
 
-        self.assertEqual(len(parse_attempts), 1)
+        # first attempt fails, second attempt is the text-extraction fallback
+        self.assertEqual(len(parse_attempts), 2)
         self.assertIn("ValidContent", parse_attempts[-1])
+        # the object must end up fully initialized, ie always have a childNodes attribute
+        self.assertTrue(hasattr(xml_string, 'childNodes'))
 
 
 class TestAASreference(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Strip leftover `xlink:*` attributes (eg `xlink:type`) during reference cleanup in `JATSxml.py`, since the `xlink` namespace is never declared once a reference is extracted and parsed as a standalone XML snippet — this was causing expat to raise an "unbound prefix" error.
- Harden `XmlString`'s tag-removal recovery loop in `xmlFile.py` so a failed match falls through to the text-extraction fallback instead of silently returning with the object missing its `childNodes` attribute, which was surfacing as an uncaught `AttributeError: childNodes`.
- Update `test_ref_parsers_xml.py::TestXmlString::test_init_exception`, which had encoded the old buggy behavior as its expectation.

Fixes #42

## Test plan
- [x] `python adsrefpipe/refparsers/JATSxml.py -f 2014ITGRS..52.2326P.jats.xml` no longer raises, parses all references
- [x] `python adsrefpipe/refparsers/JATSxml.py -f 2014ITGRS..52.2314Y.jats.xml` (previously-passing file) still parses correctly
- [x] Full unit test suite passes (260/260)

🤖 Generated with [Claude Code](https://claude.com/claude-code)